### PR TITLE
Convert cooljeanius/MacPorts-fork to GitHub Actions

### DIFF
--- a/.github/workflows/macports-fork.yml
+++ b/.github/workflows/macports-fork.yml
@@ -1,0 +1,30 @@
+name: cooljeanius/MacPorts-fork
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.5.0
+#     # 'Transformers::TravisCI::Scripts::Dependencies' dependencies are currently unsupported
+#     # 'compiler' was not transformed because there is no suitable equivalent in GitHub Actions
+    - run: sudo apt-get update
+    - run: sudo apt-get install autotools-dev debhelper gobjc gobjc++ gobjc-multilib gobjc++-multilib gobjc-4.6 libgnustep-base-dev gnustep-core-devel sqlite libsqlite3-dev openssl libcurl4-openssl-dev curl tcl tcl-dev tcl-doc tclthread tclreadline freebsd-buildutils binutils libc6-dev perl doxygen swig2.0 cvs ed pax rlwrap
+    - run: export PATH=${PATH}:/usr/lib/freebsd && env | uniq | sort | uniq
+    - run: "./configure --with-objc-runtime=GNU --with-objc-foundation=GNU --enable-maintainer-mode --enable-symbols --enable-readline && make"
+    - run: pwd && make test
+      if: "${{ success() }}"
+    - run: cat config.log
+      if: "${{ failure() }}"
+    strategy:
+      matrix:
+        compiler:
+        - clang
+        - gcc


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/cooljeanius/MacPorts-fork) :tada: