### PR TITLE
Fix code scanning alert no. 4: Likely overrunning write

### DIFF
--- a/src/thread2.6/generic/threadPoolCmd.c
+++ b/src/thread2.6/generic/threadPoolCmd.c
@@ -287,7 +287,7 @@ TpoolCreateObjCmd(dummy, interp, objc, objv)
     SpliceIn(tpoolPtr, tpoolList);
     Tcl_MutexUnlock(&listMutex);
 
-    sprintf(buf, "%s%p", TPOOL_HNDLPREFIX, tpoolPtr);
+    snprintf(buf, sizeof(buf), "%s%p", TPOOL_HNDLPREFIX, tpoolPtr);
     Tcl_SetObjResult(interp, Tcl_NewStringObj(buf, -1));
 
     return TCL_OK;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/MacPorts-fork/security/code-scanning/4](https://github.com/cooljeanius/MacPorts-fork/security/code-scanning/4)

To fix the buffer overflow issue, we should replace the `sprintf` call with `snprintf`, which allows us to specify the maximum number of bytes to write to the buffer. This ensures that we do not exceed the buffer's capacity.

- Identify the size of the buffer `buf`.
- Replace the `sprintf` call with `snprintf`, specifying the size of the buffer as the maximum number of bytes to write.
- Ensure that the buffer size is sufficient to hold the formatted string, including the null terminator.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
