### PR TITLE
Potential fix for code scanning alert no. 7: Redundant null check due to previous dereference

### DIFF
--- a/src/pextlib1.0/strsed.c
+++ b/src/pextlib1.0/strsed.c
@@ -455,7 +455,7 @@ int *range;
     if (!(from = backslash_eliminate(from, REGEX, MEM_FROM))){
         RETURN(0);
     }
-    if (to && !(to = backslash_eliminate(to, REPLACEMENT, MEM_TO))){
+    if (!(to = backslash_eliminate(to, REPLACEMENT, MEM_TO))){
         RETURN(0);
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/MacPorts-fork/security/code-scanning/7](https://github.com/cooljeanius/MacPorts-fork/security/code-scanning/7)

To fix this without changing functionality, remove the impossible/ineffective null guard from the backslash elimination call and keep only the failure check of `backslash_eliminate(...)`.

Best single change in `src/pextlib1.0/strsed.c`:
- Replace:
  - `if (to && !(to = backslash_eliminate(to, REPLACEMENT, MEM_TO))){`
- With:
  - `if (!(to = backslash_eliminate(to, REPLACEMENT, MEM_TO))){`

Why this is best:
- It aligns with prior dereference semantics (`to` is already assumed valid earlier).
- It preserves current behavior for valid inputs.
- It eliminates misleading dead safety logic and satisfies the static analysis warning.
- No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
