### PR TITLE
Potential fix for code scanning alert no. 6: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/pextlib1.0/xinstall.c
+++ b/src/pextlib1.0/xinstall.c
@@ -443,12 +443,22 @@ install(Tcl_Interp *interp, const char *from_name, const char *to_name, u_long f
 
 	/* If try to install NULL file to a directory, fails. */
 	if (flags & DIRECTORY || strcmp(from_name, _PATH_DEVNULL)) {
-		if (stat(from_name, &from_sb)) {
+		if ((from_fd = open(from_name, O_RDONLY, 0)) < 0) {
+			char errmsg[255];
+
+			snprintf(errmsg, sizeof errmsg, "%s: Unable to open: %s, %s",
+				 funcname, from_name, strerror(errno));
+			Tcl_SetResult(interp, errmsg, TCL_VOLATILE);
+			return TCL_ERROR;
+		}
+		if (fstat(from_fd, &from_sb)) {
 			char errmsg[255];
 
 			snprintf(errmsg, sizeof errmsg, "%s: Cannot stat: %s, %s",
 				 funcname, from_name, strerror(errno));
 			Tcl_SetResult(interp, errmsg, TCL_VOLATILE);
+			close(from_fd);
+			from_fd = 0;
 			return TCL_ERROR;
 		}
 		if (!S_ISREG(from_sb.st_mode)) {
@@ -458,6 +468,8 @@ install(Tcl_Interp *interp, const char *from_name, const char *to_name, u_long f
 				 funcname, from_name);
 			Tcl_SetResult(interp, errmsg, TCL_VOLATILE);
 			errno = EINVAL;
+			close(from_fd);
+			from_fd = 0;
 			return TCL_ERROR;
 		}
 		/* Build the target path. */
@@ -487,14 +499,7 @@ install(Tcl_Interp *interp, const char *from_name, const char *to_name, u_long f
 	/* Only copy safe if the target exists. */
 	tempcopy = safecopy && target;
 
-	if (!devnull && (from_fd = open(from_name, O_RDONLY, 0)) < 0) {
-		char errmsg[255];
-
-		snprintf(errmsg, sizeof errmsg, "%s: Unable to open: %s, %s",
-			 funcname, from_name, strerror(errno));
-		Tcl_SetResult(interp, errmsg, TCL_VOLATILE);
-		return TCL_ERROR;
-	}
+	/* from_fd already opened and validated above when !devnull. */
 
 	/* If we don't strip, we can compare first. */
 	if (docompare && !dostrip && target) {


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/MacPorts-fork/security/code-scanning/6](https://github.com/cooljeanius/MacPorts-fork/security/code-scanning/6)

General fix: avoid doing security-relevant checks on a pathname and then opening that pathname later. Open first, then validate the opened file using descriptor-based APIs (`fstat`), and use that same descriptor for subsequent operations.

Best targeted fix here (in `src/pextlib1.0/xinstall.c` around lines 445–497):  
- Keep the existing `_PATH_DEVNULL` / DIRECTORY flow, but remove the pre-open `stat(from_name, &from_sb)` and pre-open `S_ISREG` check.  
- Open `from_name` earlier in that block (for non-devnull).  
- Immediately run `fstat(from_fd, &from_sb)` and perform `S_ISREG(from_sb.st_mode)` on that result.  
- On failure, report error and close `from_fd` before returning.  
This preserves behavior while eliminating the check/use race on `from_name` and should address both alert variants.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
