### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/macports-fork.yml
+++ b/.github/workflows/macports-fork.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "**/*"
   pull_request:
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/MacPorts-fork/security/code-scanning/5](https://github.com/cooljeanius/MacPorts-fork/security/code-scanning/5)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged regardless of repo/org defaults.

Best single fix without changing functionality: in `.github/workflows/macports-fork.yml`, add a root-level block right after the trigger section (`on:`) and before `jobs:`:

- `permissions:`
  - `contents: read`

This applies to all jobs in this workflow and is sufficient for `actions/checkout` plus local build/test steps shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
